### PR TITLE
Synchronize healing moves between players in multiplayer mode

### DIFF
--- a/.replit
+++ b/.replit
@@ -15,12 +15,12 @@ localPort = 5000
 externalPort = 80
 
 [[ports]]
-localPort = 34127
-externalPort = 4200
-
-[[ports]]
 localPort = 35957
 externalPort = 3001
+
+[[ports]]
+localPort = 36757
+externalPort = 3003
 
 [[ports]]
 localPort = 36951

--- a/client/src/lib/stores/useChessGame.tsx
+++ b/client/src/lib/stores/useChessGame.tsx
@@ -791,6 +791,27 @@ export const useChessGame = create<ChessGameState>()(
         selectedPieceForHeal: null,
         moveHistory: [...state.moveHistory, moveNotation]
       });
+
+      // CRITICAL FIX: Add multiplayer synchronization for healing moves
+      if (state.gameMode === 'pvp' && useMultiplayer.getState().isInMultiplayerMode) {
+        const multiplayerState = useMultiplayer.getState();
+        const moveNumber = multiplayerState.gameRoom?.moveCount !== undefined 
+          ? multiplayerState.gameRoom.moveCount + 1 
+          : 1;
+        const move = {
+          from: positionToString(bishopPosition),
+          to: positionToString(targetPosition),
+          piece: bishop.type,
+          player: multiplayerState.playerRole,
+          moveNumber,
+          heal: {
+            healAmount,
+            targetHealth: newHealth
+          }
+        };
+        console.log('Syncing healing move to opponent:', move);
+        useMultiplayer.getState().makeMove(move, newBoard);
+      }
     },
     
     // Promotion actions

--- a/client/src/lib/stores/useMultiplayer.tsx
+++ b/client/src/lib/stores/useMultiplayer.tsx
@@ -150,7 +150,11 @@ export const useMultiplayer = create<MultiplayerState>()(
           gameRoom: {
             id: get().roomId!,
             players: data.players,
-            status: 'playing'
+            gameState: {},
+            status: 'playing',
+            currentTurn: 'white',
+            moveCount: 0,
+            createdAt: new Date()
           },
           isWaitingForPlayer: false,
           error: null


### PR DESCRIPTION
Update `useChessGame` store to synchronize healing moves in PvP mode via the `useMultiplayer` store. Initialize `gameRoom` state in `useMultiplayer` with additional properties like `gameState`, `currentTurn`, `moveCount`, and `createdAt`.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: b72466ed-da18-4eda-8504-da285894bd6e
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/987fc1b7-58f8-4548-aa07-2dcbcc3b2581/b72466ed-da18-4eda-8504-da285894bd6e/hu0wiIy